### PR TITLE
Fixing missing library in Debian repos

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -6,7 +6,8 @@ EXPOSE 8000
 RUN apt-get update && \
    apt-get install -y --no-install-recommends \
        libmagic1 \
-       libgl1-mesa-glx \
+       libgl1 \
+       libglx-mesa0 \
        libreoffice \
        cmake \
        poppler-utils \


### PR DESCRIPTION
When trying to build the backend image I got the following error:

> Step 2/11 : WORKDIR /code
 ---> Running in 2d814b240caf
 ---> Removed intermediate container 2d814b240caf
 ---> b3a8c48f2f53
Step 3/11 : ENV PORT 8000
 ---> Running in 39aa10645c0a
 ---> Removed intermediate container 39aa10645c0a
 ---> 64f0606f4140
Step 4/11 : EXPOSE 8000
 ---> Running in 6d504b7a8857
 ---> Removed intermediate container 6d504b7a8857
 ---> 959f1c30993d
Step 5/11 : RUN apt-get update &&    apt-get install -y --no-install-recommends        libmagic1        libgl1-mesa-glx        libreoffice        cmake        poppler-utils        tesseract-ocr &&    apt-get clean &&    rm -rf /var/lib/apt/lists/*
 ---> Running in 5130366136b8
Hit:1 http://deb.debian.org/debian trixie InRelease
Get:2 http://deb.debian.org/debian trixie-updates InRelease [47.1 kB]
Get:3 http://deb.debian.org/debian-security trixie-security InRelease [43.4 kB]
Get:4 http://deb.debian.org/debian trixie/main amd64 Packages [9669 kB]
Get:5 http://deb.debian.org/debian trixie-updates/main amd64 Packages [2432 B]
Get:6 http://deb.debian.org/debian-security trixie-security/main amd64 Packages [34.0 kB]
Fetched 9796 kB in 2s (4344 kB/s)
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
Package libgl1-mesa-glx is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
E: Package 'libgl1-mesa-glx' has no installation candidate
The command '/bin/sh -c apt-get update &&    apt-get install -y --no-install-recommends        libmagic1        libgl1-mesa-glx        libreoffice        cmake        poppler-utils        tesseract-ocr &&    apt-get clean &&    rm -rf /var/lib/apt/lists/*' returned a non-zero code: 100

I followed these instructions: https://askubuntu.com/a/1520333. And the image built successfully.

What I basically did was replace an unsupported package that was no longer in the Debian repositories for the image being used for Python in this Dockerfile.
